### PR TITLE
API uplift for JOSM v19528

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
   <!-- enter the SVN commit message -->
   <property name="commit.message" value="Commit message"/>
   <!-- enter the *lowest* JOSM version this plugin is currently compatible with -->
-  <property name="plugin.main.version" value="19330"/>
+  <property name="plugin.main.version" value="19528"/>
   <property name="plugin.author" value="Taylor Smock"/>
   <property name="plugin.class" value="org.openstreetmap.josm.plugins.maproulette.MapRoulette"/>
   <property name="plugin.description" value="MapRoulette Tasks in JOSM"/>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <plugin.src.dir>${project.basedir}/src/main/java</plugin.src.dir>
         <plugin.test.dir>${project.basedir}/src/test/unit</plugin.test.dir>
         <plugin.resources.dir>${project.basedir}/src/main/resources</plugin.resources.dir>
-        <plugin.main.version>19044</plugin.main.version>
+        <plugin.main.version>19528</plugin.main.version>
         <plugin.author>Taylor Smock</plugin.author>
         <plugin.class>org.openstreetmap.josm.plugins.maproulette.MapRoulette</plugin.class>
         <plugin.description>MapRoulette Tasks in JOSM</plugin.description>

--- a/src/main/java/org/openstreetmap/josm/plugins/maproulette/api/model/AbstractNode.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/maproulette/api/model/AbstractNode.java
@@ -18,6 +18,7 @@ import org.openstreetmap.josm.data.osm.OsmData;
 import org.openstreetmap.josm.data.osm.OsmPrimitiveType;
 import org.openstreetmap.josm.data.osm.User;
 import org.openstreetmap.josm.data.osm.visitor.PrimitiveVisitor;
+import org.openstreetmap.josm.gui.mappaint.ElemStyles;
 import org.openstreetmap.josm.gui.mappaint.StyleCache;
 
 /**
@@ -243,24 +244,27 @@ public interface AbstractNode extends INode {
     }
 
     @Override
-    default StyleCache getCachedStyle() {
+    default StyleCache getCachedStyle(ElemStyles elemStyles) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    default void setCachedStyle(StyleCache mappaintStyle) {
+    default void setCachedStyle(ElemStyles elemStyles, StyleCache mappaintStyle) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    default boolean isCachedStyleUpToDate() {
+    default boolean isCachedStyleUpToDate(ElemStyles elemStyles) {
         return false;
     }
 
     @Override
-    default void declareCachedStyleUpToDate() {
+    default void declareCachedStyleUpToDate(ElemStyles elemStyles) {
         throw new UnsupportedOperationException();
     }
+    default void clearCachedStyle(){
+        //do nothing
+    };
 
     @Override
     default Map<String, String> getKeys() {


### PR DESCRIPTION
MapRoulette requires API uplift according to the latest changes in JOSM.  See [JOSM Ticket #24637](https://josm.openstreetmap.de/ticket/24637).